### PR TITLE
Ability to run actions manually

### DIFF
--- a/.github/workflows/casino_deploy.yml
+++ b/.github/workflows/casino_deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'casino/**'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
# Pull Request Template

## Summary
This pull request updates the GitHub Actions workflow configuration to enable manual triggering of the deployment workflow.

* [`.github/workflows/casino_deploy.yml`](diffhunk://#diff-f82bafec867f9210a99f51ea7f54602424bfd7f30024a45496211d94a7fe6081R9): Added the `workflow_dispatch` event to allow the deployment workflow to be triggered manually.

## Changes
- [x] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Documentation

## Checklist
- [ ] I’ve tested my changes
- [ ] I’ve updated related documentation
- [x] I’ve followed the coding style guidelines
