### PR TITLE
Implemented feature to avoid resending message command

### DIFF
--- a/casino/main.py
+++ b/casino/main.py
@@ -141,6 +141,7 @@ class CasinoHomeView(discord.ui.View):
 async def on_ready():
     await init_db()  # DB setup on start
     await bot.tree.sync()  # Sync slash commands
+    bot.add_view(CasinoHomeView()) # Always register the persistent view class
     print(f"✅ {bot.user} is ready!")
 
 # Slash command to show the casino home screen message publicly


### PR DESCRIPTION
# Pull Request Template

## Summary
This pull request includes a small but significant change to the `casino/main.py` file. The change ensures that the persistent view class `CasinoHomeView` is always registered when the bot starts.

* [`casino/main.py`](diffhunk://#diff-bf53c4168377a081bfb79a628445d4c0315686a1d80d936cf9074fa884625cc1R144): Added a call to `bot.add_view(CasinoHomeView())` in the `on_ready` method to ensure the persistent view class is registered when the bot is ready.

## Changes
- [x] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I’ve tested my changes
- [ ] I’ve updated related documentation
- [x] I’ve followed the coding style guidelines
