### PR TITLE
Wheel not enough balance fix

### DIFF
--- a/casino/wheel_of_fortune.py
+++ b/casino/wheel_of_fortune.py
@@ -46,7 +46,10 @@ async def spin_wheel_logic(interaction: discord.Interaction, bet=1000, view=None
     async with lock:
         bal, _ = await get_balance(uid, interaction.user.name)
         if bal < bet:
-            await interaction.response.send_message(f"❌ Not enough coins! You need at least {bet}.", ephemeral=True)
+            if interaction.response.is_done():
+                await interaction.followup.send(f"❌ Not enough coins! You need at least {bet}.", ephemeral=True)
+            else:
+                await interaction.response.send_message(f"❌ Not enough coins! You need at least {bet}.", ephemeral=True)
             return
         
         wheel_state = await get_wheel_state(uid)


### PR DESCRIPTION
# Pull Request Template

## Summary
This pull request improves the user experience when handling insufficient balance errors in the `spin_wheel_logic` function. The main change is to ensure that the error message is sent using the correct Discord interaction method depending on the response state.

Error handling enhancement:

* Updated `spin_wheel_logic` in `casino/wheel_of_fortune.py` to check if the interaction response is already completed, and use `interaction.followup.send` if so, otherwise use `interaction.response.send_message`, ensuring the error message is always sent appropriately.

## Changes
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] I’ve tested my changes
- [x] I’ve updated related documentation
- [x] I’ve followed the coding style guidelines
