### PR TITLE
changed random in the wheel + updated leaderboard

### DIFF
--- a/casino/main.py
+++ b/casino/main.py
@@ -123,11 +123,11 @@ class CasinoHomeView(discord.ui.View):
         if not top_rows:
             await interaction.response.send_message("No one gambled yet :(", ephemeral=True)
             return
+        
+        leaderboard = [f"**#1 — {top_rows[0]['username']}** — {top_rows[0]['balance']}🤑"]
 
-        # Top 5 leaderboard formatting
-        leaderboard = "\n".join(
-            [f"**#{i+1}** — {row['username']}" for i, row in enumerate(top_rows[:5])]
-        )
+        # For ranks #2 to #5 show only usernames
+        leaderboard += "\n".join([f"**#{i+2}** — {row['username']}" for i, row in enumerate(top_rows[1:5])])
 
         # Determine user rank
         user_id = interaction.user.id

--- a/casino/wheel_of_fortune.py
+++ b/casino/wheel_of_fortune.py
@@ -56,12 +56,12 @@ async def spin_wheel_logic(interaction: discord.Interaction, bet=1000, view=None
 
     await interaction.edit_original_response(embed=embed_wheel(wheel_state), view=view)
 
-    winner = random.randint(10, 30)
+    winner = random.randint(2*len(wheel_of_fortune), 4*(wheel_of_fortune))
     final_index = (wheel_state + winner) % len(wheel_of_fortune)
 
     for step in range(winner+1):
         pos = (step + wheel_state) % len(wheel_of_fortune)
-        delay = 0.05 + ((step / winner)**3) * 1.1
+        delay = 0.05 + ((step / winner)**3) * 0.9
         await asyncio.sleep(delay)
         try:
             await interaction.edit_original_response(embed=embed_wheel(pos), view=view)


### PR DESCRIPTION
# Pull Request Template

## Summary
This pull request introduces improvements to the leaderboard display in the casino module and refines the randomization logic and animation pacing in the Wheel of Fortune game.

**Leaderboard Display Enhancements:**

* The leaderboard now highlights the top player by displaying both their username and balance with a special emoji, while ranks #2 to #5 show only usernames for a clearer and more engaging presentation.

**Wheel of Fortune Logic and Animation Tweaks:**

* The winner selection range is now dynamically based on the wheel's size, making the outcome more variable and game scaling more robust.
* The animation delay curve has been adjusted to create a slightly faster and smoother spinning effect for a better user experience.

## Changes
- [ ] Feature
- [ ] Bugfix
- [x] Refactor
- [ ] Documentation

## Checklist
- [x] I’ve tested my changes
- [x] I’ve updated related documentation
- [x] I’ve followed the coding style guidelines
