### PR TITLE
Limit simulteneous wheel spins per user

### DIFF
--- a/casino/main.py
+++ b/casino/main.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from database import init_pool, get_pool, init_db, get_balance, update_balance, get_user_lock
 from slots import SlotView
 from blackjack import BlackjackBetView
-from wheel_of_fortune import FortuneView, embed_wheel, get_wheel_state
+from wheel_of_fortune import FortuneView, embed_wheel, get_wheel_state, active_wheel_spins
 
 intents = discord.Intents.default()
 bot = commands.Bot(command_prefix=None, intents=intents)
@@ -74,6 +74,13 @@ class CasinoHomeView(discord.ui.View):
 
     @discord.ui.button(label="🍀 Spin Fortune Wheel", style=discord.ButtonStyle.success, custom_id="goto_fortune")
     async def goto_fortune(self, interaction: discord.Interaction, button: discord.ui.Button):
+        uid = interaction.user.id
+        if uid in active_wheel_spins:
+            await interaction.response.send_message(
+                "⚠️ You are already spinning the wheel!", ephemeral=True
+            )
+            return
+        active_wheel_spins.add(uid)
         await interaction.response.send_message(
             "🍀 **Fortune Wheel**\nPress to spin and test your luck!",
             embed=embed_wheel(await get_wheel_state(interaction.user.id)),

--- a/casino/wheel_of_fortune.py
+++ b/casino/wheel_of_fortune.py
@@ -49,13 +49,6 @@ async def update_wheel_state(user_id: int, state: int):
 async def spin_wheel_logic(interaction: discord.Interaction, bet=1000, view=None):
     uid = interaction.user.id
 
-    if uid in active_wheel_spins:
-        await interaction.response.send_message(
-            "⚠️ You are already spinning the wheel!", ephemeral=True
-        )
-        return
-    active_wheel_spins.add(uid)
-
     lock = get_user_lock(uid)
 
     async with lock:


### PR DESCRIPTION
# Pull Request Template

## Summary
This pull request refactors how the "Fortune Wheel" spin state is managed to prevent users from spinning the wheel multiple times concurrently. The main change is moving the check for active spins from the wheel logic to the UI layer, improving separation of concerns and user experience.

**Improvements to user interaction and state management:**

* Moved the check for whether a user is already spinning the wheel from `spin_wheel_logic` in `casino/wheel_of_fortune.py` to the `goto_fortune` button handler in `casino/main.py`, ensuring users receive immediate feedback before invoking the spin logic. [[1]](diffhunk://#diff-6275e7a5e5fb5c2311c1e03b27b15c1339128f86f7cd936930dcd2533091bfd5L52-L58) [[2]](diffhunk://#diff-bf53c4168377a081bfb79a628445d4c0315686a1d80d936cf9074fa884625cc1R77-R83)
* Added the `active_wheel_spins` set to the wheel import in `casino/main.py` to support the updated spin state management.

## Changes
- [ ] Feature
- [x] Bugfix
- [x] Refactor
- [ ] Documentation

## Checklist
- [ ] I’ve tested my changes
- [ ] I’ve updated related documentation
- [ ] I’ve followed the coding style guidelines
